### PR TITLE
Add printing-press service

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -267,6 +267,28 @@ module Config
       auto_update: true                                      # Whether to auto-update when repo changes
     },
     {
+      name: 'printing-press',                                # Service name
+      repo_url: 'git@github.com:philipithomas/printing-press.git', # Git repo
+      local_path: "#{CODE_DIR}/printing-press",              # Where to clone the repo
+      container_config: {                                    # Container configuration after build
+        image_name: 'printing-press',                        # Docker image name to create
+        ports: ['4242:8080'],                                # Map host 4242 -> container 8080
+        environment: {                                       # Environment variables from 1Password
+          DATABASE_URL: { type: '1password', item: 'printing-press', field: 'DATABASE_URL' },
+          M2M_API_KEY: { type: '1password', item: 'printing-press', field: 'M2M_API_KEY' },
+          AWS_ACCESS_KEY_ID: { type: '1password', item: 'printing-press', field: 'AWS_ACCESS_KEY_ID' },
+          AWS_SECRET_ACCESS_KEY: { type: '1password', item: 'printing-press', field: 'AWS_SECRET_ACCESS_KEY' },
+          AWS_REGION: { type: '1password', item: 'printing-press', field: 'AWS_REGION' },
+          SES_FROM_EMAIL: { type: '1password', item: 'printing-press', field: 'SES_FROM_EMAIL' },
+          EMAIL_BACKEND: 'ses',
+          SITE_URL: 'https://philipithomas.com',
+          HOST: '0.0.0.0',
+          PORT: '8080'
+        }
+      },
+      auto_update: true                                      # Whether to auto-update when repo changes
+    },
+    {
       name: 'trivet',                                        # Service name
       repo_url: 'git@github.com:contraptionco/trivet.git',   # Git repo
       local_path: "#{CODE_DIR}/trivet",                      # Where to clone the repo

--- a/config.yml
+++ b/config.yml
@@ -45,4 +45,6 @@ ingress:
     service: http://localhost:3002
   - hostname: trivet.contraption.co
     service: http://localhost:3003
+  - hostname: printing-press.philipithomas.com
+    service: http://localhost:4242
   - service: http_status:404


### PR DESCRIPTION
## Summary
- Adds printing-press (Rust/Axum subscriber management + email backend) as a git service
- Port 4242 on host → 8080 in container
- Cloudflare tunnel ingress for printing-press.philipithomas.com
- All secrets from 1Password item "printing-press"

## 1Password fields required
| Field | Value |
|---|---|
| `DATABASE_URL` | `postgres://user:pass@postgres:5432/printing_press` |
| `M2M_API_KEY` | API key shared with bully-pulpit |
| `AWS_ACCESS_KEY_ID` | SES credentials |
| `AWS_SECRET_ACCESS_KEY` | SES secret |
| `AWS_REGION` | `us-east-1` |
| `SES_FROM_EMAIL` | `mail@philipithomas.com` |

## Setup
- Create DNS CNAME for `printing-press.philipithomas.com` → Cloudflare tunnel
- Create `printing_press` database in Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)