### PR TITLE
Remove bully-pulpit service (migrated to Vercel)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -268,17 +268,6 @@ module Config
       auto_update: true                                      # Whether to auto-update when repo changes
     },
     {
-      name: 'bully-pulpit',                                  # Service name
-      repo_url: 'git@github.com:philipithomas/bully-pulpit.git', # Git repo
-      local_path: "#{CODE_DIR}/bully-pulpit",                # Where to clone the repo
-      env_config: { type: '1password', item: 'bully-pulpit', field: 'env' },
-      container_config: {                                    # Container configuration after build
-        image_name: 'bully-pulpit',                          # Docker image name to create
-        ports: ['4243:3000']                                 # Map host 4243 -> container 3000
-      },
-      auto_update: true                                      # Whether to auto-update when repo changes
-    },
-    {
       name: 'trivet',                                        # Service name
       repo_url: 'git@github.com:contraptionco/trivet.git',   # Git repo
       local_path: "#{CODE_DIR}/trivet",                      # Where to clone the repo

--- a/config.yml
+++ b/config.yml
@@ -33,12 +33,6 @@ ingress:
     service: http://localhost:3003
   - hostname: printing-press.contraption.co
     service: http://localhost:4242
-  - hostname: bully-pulpit.contraption.co
-    service: http://localhost:4243
-  - hostname: www.philipithomas.com
-    service: http://localhost:4243
-  - hostname: bully-pulpit.philipithomas.com
-    service: http://localhost:4243
   - hostname: philipandemma.com
     service: http://localhost:3006
   - hostname: www.philipandemma.com


### PR DESCRIPTION
Removes the `bully-pulpit` service now that it's hosted on Vercel.

- **config.rb**: drop the `bully-pulpit` service definition (repo clone, 1Password env, Docker image, port `4243:3000`).
- **config.yml**: remove the three ingress hostnames that pointed at port 4243:
  - `bully-pulpit.contraption.co`
  - `www.philipithomas.com`
  - `bully-pulpit.philipithomas.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)