### PR TITLE
Remove philipithomas-fonts service (migrated to Vercel)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -216,16 +216,6 @@ module Config
       auto_update: true                                      # Whether to auto-update when repo changes
     },
     {
-      name: 'philipithomas-fonts',                             # Service name
-      repo_url: 'git@github.com:philipithomas/fonts.git',     # Git repo
-      local_path: "#{CODE_DIR}/philipithomas-fonts",           # Where to clone the repo
-      container_config: {                                      # Container configuration after build
-        image_name: 'philipithomas-fonts',                     # Docker image name to create
-        ports: ['3004:80']                                     # Map host 3004 -> container 80 (nginx default)
-      },
-      auto_update: true                                        # Whether to auto-update when repo changes
-    },
-    {
       name: 'wedding-next',                                      # Service name
       repo_url: 'git@github.com:philipithomas/wedding-next.git', # Git repo
       local_path: "#{CODE_DIR}/wedding-next",                    # Where to clone the repo

--- a/config.yml
+++ b/config.yml
@@ -25,10 +25,6 @@ ingress:
     service: http://localhost:3001
   - hostname: fonts.contraption.co
     service: http://localhost:3002
-  - hostname: philipithomas-fonts.contraption.co
-    service: http://localhost:3004
-  - hostname: fonts.philipithomas.com
-    service: http://localhost:3004
   - hostname: trivet.contraption.co
     service: http://localhost:3003
   - hostname: printing-press.contraption.co


### PR DESCRIPTION
fonts.philipithomas.com has moved to Vercel, so the self-hosted nginx container is no longer needed on the toolbox.

- Removes the `philipithomas-fonts` service definition from `config.rb` (port 3004 nginx container)
- Removes the `philipithomas-fonts.contraption.co` and `fonts.philipithomas.com` hostname routes from `config.yml`

The `fonts` service for contraptionco/fonts (fonts.contraption.co) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)